### PR TITLE
Add reusable card components

### DIFF
--- a/packages/common-components/src/components/CustomInfoCard/CustomInfoCard.test.tsx
+++ b/packages/common-components/src/components/CustomInfoCard/CustomInfoCard.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import { CustomInfoCard } from './CustomInfoCard';
+
+const renderCard = (ui: React.ReactElement) =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={createTheme()}>{ui}</ThemeProvider>
+    </MemoryRouter>,
+  );
+
+describe('CustomInfoCard', () => {
+  it('renders title with data sources', () => {
+    renderCard(
+      <CustomInfoCard title="Title" dataSources={['ds1', 'ds2']}>
+        <div>content</div>
+      </CustomInfoCard>,
+    );
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByTestId('data-sources')).toHaveTextContent('| ds1 | ds2');
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('aligns footer buttons to the right', () => {
+    renderCard(
+      <CustomInfoCard
+        title="Title"
+        footerButtons={<Button>ok</Button>}
+      >
+        <div>content</div>
+      </CustomInfoCard>,
+    );
+
+    const actions = screen.getByText('ok').closest('.MuiCardActions-root');
+    expect(actions).toHaveStyle('justify-content: flex-end');
+  });
+});

--- a/packages/common-components/src/components/CustomInfoCard/CustomInfoCard.tsx
+++ b/packages/common-components/src/components/CustomInfoCard/CustomInfoCard.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardHeader from '@mui/material/CardHeader';
+import CardContent from '@mui/material/CardContent';
+import CardActions from '@mui/material/CardActions';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+
+export interface CustomInfoCardProps {
+  title: React.ReactNode;
+  dataSources?: string[];
+  footerButtons?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+/**
+ * A reusable info card with optional data sources display and footer buttons.
+ * @public
+ */
+export function CustomInfoCard(props: CustomInfoCardProps) {
+  const { title, dataSources = [], footerButtons, children } = props;
+
+  const dataSourceText = dataSources.join(' | ');
+
+  const header = (
+    <Box display="flex" alignItems="center">
+      <Typography variant="h6">{title}</Typography>
+      {dataSourceText && (
+        <Typography
+          variant="subtitle2"
+          color="text.secondary"
+          sx={{ ml: 1 }}
+        >
+          | {dataSourceText}
+        </Typography>
+      )}
+    </Box>
+  );
+
+  return (
+    <Card>
+      <CardHeader title={header} />
+      <CardContent>{children}</CardContent>
+      {footerButtons && (
+        <CardActions sx={{ justifyContent: 'flex-end' }}>
+          {footerButtons}
+        </CardActions>
+      )}
+    </Card>
+  );
+}

--- a/packages/common-components/src/components/PreuseCard/PreuseCard.test.tsx
+++ b/packages/common-components/src/components/PreuseCard/PreuseCard.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
+import { PreuseCard } from './PreuseCard';
+
+const renderCard = (ui: React.ReactElement) =>
+  render(
+    <MemoryRouter>
+      <ThemeProvider theme={createTheme()}>{ui}</ThemeProvider>
+    </MemoryRouter>,
+  );
+
+describe('PreuseCard', () => {
+  it('shows skim content when collapsed and hides children', () => {
+    renderCard(
+      <PreuseCard title="Title" skimContent={<span>skim</span>}>
+        <div>details</div>
+      </PreuseCard>,
+    );
+
+    expect(screen.getByText('skim')).toBeInTheDocument();
+    expect(screen.queryByText('details')).toBeNull();
+  });
+
+  it('expands to show children and hide skim content', () => {
+    renderCard(
+      <PreuseCard title="Title" skimContent={<span>skim</span>}>
+        <div>details</div>
+      </PreuseCard>,
+    );
+
+    fireEvent.click(screen.getByTestId('toggle-button'));
+
+    expect(screen.getByText('details')).toBeInTheDocument();
+    expect(screen.queryByText('skim')).toBeNull();
+  });
+});

--- a/packages/common-components/src/components/PreuseCard/PreuseCard.tsx
+++ b/packages/common-components/src/components/PreuseCard/PreuseCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import Typography from '@mui/material/Typography';
+import { CustomInfoCard } from '../CustomInfoCard/CustomInfoCard';
+
+export interface PreuseCardProps {
+  title: React.ReactNode;
+  skimContent?: React.ReactNode;
+  dataSources?: string[];
+  footerButtons?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+/**
+ * A collapsible card that hides its content by default.
+ * @public
+ */
+export function PreuseCard({
+  title,
+  skimContent,
+  dataSources,
+  footerButtons,
+  children,
+}: PreuseCardProps) {
+  const [expanded, setExpanded] = React.useState(false);
+
+  const toggle = () => setExpanded(prev => !prev);
+
+  const header = (
+    <Box display="flex" alignItems="center" flexWrap="wrap">
+      <IconButton size="small" onClick={toggle} data-testid="toggle-button">
+        {expanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+      </IconButton>
+      <Typography variant="h6" sx={{ ml: 1 }}>
+        {title}
+      </Typography>
+      {!expanded && skimContent && (
+        <Box sx={{ ml: 1 }}>{skimContent}</Box>
+      )}
+    </Box>
+  );
+
+  return (
+    <CustomInfoCard
+      title={header}
+      dataSources={dataSources}
+      footerButtons={footerButtons}
+    >
+      {expanded && children}
+    </CustomInfoCard>
+  );
+}

--- a/packages/common-components/src/index.ts
+++ b/packages/common-components/src/index.ts
@@ -11,4 +11,5 @@ export * from './hooks/useClientEntityAccessCheck/accessCheckers';
 export * from './hooks/useClientEntityAccessCheck/useEntityAccessCheck';
 export * from './components/ConditionalOwnership/ConditionalOwnership';
 export * from './components/MissingAnnotationsCard/MissingAnnotationsCard';
-      
+export * from './components/CustomInfoCard/CustomInfoCard';
+export * from './components/PreuseCard/PreuseCard';


### PR DESCRIPTION
## Summary
- add CustomInfoCard with optional data sources and footer
- create PreuseCard for collapsible display
- export new components from common-components package
- add unit tests for the new components

## Testing
- `yarn test packages/common-components` *(fails: Error when performing the request to https://repo.yarnpkg.com/...)*

------
https://chatgpt.com/codex/tasks/task_e_684b71f788ac832b8e732034f93d2696