### PR TITLE
feat: Add ResilienceCard component to entity page

### DIFF
--- a/packages/app/src/components/catalog/EntityPage.tsx
+++ b/packages/app/src/components/catalog/EntityPage.tsx
@@ -53,7 +53,7 @@ import {
 } from '@backstage/catalog-model';
 import { MissingAnnotationsCard } from 'common-components';
 import { PreuseCard } from 'common-components';
-import { CodeCoverageCard } from 'backstage-plugin-helloworld';
+import { CodeCoverageCard, ResilienceCard } from 'backstage-plugin-helloworld';
 import { ReportIssue } from '@backstage/plugin-techdocs-module-addons-contrib';
 import {
   EntityKubernetesContent,
@@ -128,6 +128,9 @@ const overviewContent = (
     </Grid>
     <Grid item md={6} xs={12}>
       <EntityCatalogGraphCard variant="gridItem" height={400} />
+    </Grid>
+    <Grid item md={12} xs={12}>
+      <ResilienceCard />
     </Grid>
     <Grid item md={4} xs={12}>
       <EntityLinksCard />

--- a/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.test.tsx
+++ b/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ResilienceCard } from './ResilienceCard';
+
+jest.mock('common-components', () => ({
+  CustomInfoCard: ({ title, children, skimContent }: any) => (
+    <div>
+      <h2>{title}</h2>
+      <div data-testid="skim-content">{skimContent}</div>
+      <div data-testid="card-content">{children}</div>
+    </div>
+  ),
+}));
+
+describe('ResilienceCard', () => {
+  it('renders the resilience card with correct title', () => {
+    render(<ResilienceCard />);
+    expect(screen.getByText('Resilience')).toBeInTheDocument();
+  });
+
+  it('displays chaos experiment compliance status', () => {
+    render(<ResilienceCard />);
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('Chaos Experiment Compliant')).toBeInTheDocument();
+  });
+
+  it('displays incident counts', () => {
+    render(<ResilienceCard />);
+    expect(screen.getByText('1')).toBeInTheDocument(); // Critical
+    expect(screen.getByText('3')).toBeInTheDocument(); // High/Medium
+    expect(screen.getByText('10')).toBeInTheDocument(); // Low
+  });
+
+  it('displays chaos experiment details in expanded content', () => {
+    render(<ResilienceCard />);
+    expect(screen.getByText(/Chaos Experiments Compliant: Yes/)).toBeInTheDocument();
+    expect(screen.getByText(/In Scope: No/)).toBeInTheDocument();
+    expect(screen.getByText(/Catchup Date: May 20, 2024/)).toBeInTheDocument();
+  });
+});

--- a/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
+++ b/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { CustomInfoCard } from 'common-components';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import Button from '@mui/material/Button';
+import { useResilienceData } from './useResilienceData';
+
+const ResilienceSkimContent = () => {
+  const { chaosExperiment, incidents } = useResilienceData();
+  
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Typography variant="body1" sx={{ fontWeight: 'bold' }}>
+        {chaosExperiment.compliant ? 'Yes' : 'No'}
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Chaos Experiment Compliant
+      </Typography>
+      <Typography variant="body2" color="text.secondary">
+        Incident Management
+      </Typography>
+      <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+        {incidents.critical}
+      </Box>
+      <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+        {incidents.high}
+      </Box>
+      <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+        {incidents.medium}
+      </Box>
+      <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+        {incidents.low}
+      </Box>
+    </Box>
+  );
+};
+
+const ResilienceExpandedContent = () => {
+  const { chaosExperiment, incidents } = useResilienceData();
+  
+  return (
+    <Grid container spacing={2}>
+      <Grid item xs={6}>
+        <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
+          CHAOS EXPERIMENT
+        </Typography>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+          <Typography variant="body2">
+            Chaos Experiments Compliant: {chaosExperiment.compliant ? 'Yes' : 'No'}.
+          </Typography>
+          <Typography variant="body2">
+            In Scope: {chaosExperiment.inScope ? 'Yes' : 'No'}
+          </Typography>
+          <Typography variant="body2">
+            Catchup Date: {chaosExperiment.catchupDate}
+          </Typography>
+          <Typography variant="body2">
+            Snapshot Facing Date: {chaosExperiment.snapshotFacingDate || 'NO'}
+          </Typography>
+        </Box>
+      </Grid>
+      <Grid item xs={6}>
+        <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
+          INCIDENT MANAGEMENT
+        </Typography>
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+            Critical {incidents.critical}
+          </Box>
+          <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+            High {incidents.high}
+          </Box>
+          <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+            Medium {incidents.medium}
+          </Box>
+          <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+            Low & Below {incidents.low}
+          </Box>
+        </Box>
+      </Grid>
+    </Grid>
+  );
+};
+
+export const ResilienceCard = () => {
+  return (
+    <CustomInfoCard
+      title="Resilience"
+      subheader="Resilience Information"
+      dataSources={['Chaos Experiment', 'Incident Management']}
+      skimContent={<ResilienceSkimContent />}
+      footerButtonsComponent={
+        <Box sx={{ display: 'flex', gap: 1 }}>
+          <Button variant="outlined" size="small" onClick={() => console.log('View Details clicked')}>
+            View Details
+          </Button>
+          <Button variant="contained" size="small" onClick={() => console.log('Actions clicked')}>
+            Actions
+          </Button>
+        </Box>
+      }
+      menuActions={[
+        { label: 'Refresh Data', onClick: () => console.log('Refresh') },
+        { label: 'Export', onClick: () => console.log('Export') },
+      ]}
+    >
+      <ResilienceExpandedContent />
+    </CustomInfoCard>
+  );
+};

--- a/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
+++ b/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
@@ -41,41 +41,45 @@ const ResilienceExpandedContent = () => {
   
   return (
     <Grid container spacing={2}>
-      <Grid item xs={6}>
-        <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-          CHAOS EXPERIMENT
-        </Typography>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-          <Typography variant="body2">
-            Chaos Experiments Compliant: {chaosExperiment.compliant ? 'Yes' : 'No'}.
+      <Grid item xs={12}>
+        <Box sx={{ bgcolor: 'background.default', p: 2, borderRadius: 1 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
+            CHAOS EXPERIMENT
           </Typography>
-          <Typography variant="body2">
-            In Scope: {chaosExperiment.inScope ? 'Yes' : 'No'}
-          </Typography>
-          <Typography variant="body2">
-            Catchup Date: {chaosExperiment.catchupDate}
-          </Typography>
-          <Typography variant="body2">
-            Snapshot Facing Date: {chaosExperiment.snapshotFacingDate || 'NO'}
-          </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Typography variant="body2">
+              Chaos Experiments Compliant: {chaosExperiment.compliant ? 'Yes' : 'No'}.
+            </Typography>
+            <Typography variant="body2">
+              In Scope: {chaosExperiment.inScope ? 'Yes' : 'No'}
+            </Typography>
+            <Typography variant="body2">
+              Catchup Date: {chaosExperiment.catchupDate}
+            </Typography>
+            <Typography variant="body2">
+              Snapshot Facing Date: {chaosExperiment.snapshotFacingDate || 'NO'}
+            </Typography>
+          </Box>
         </Box>
       </Grid>
-      <Grid item xs={6}>
-        <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-          INCIDENT MANAGEMENT
-        </Typography>
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-            Critical {incidents.critical}
-          </Box>
-          <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-            High {incidents.high}
-          </Box>
-          <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-            Medium {incidents.medium}
-          </Box>
-          <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-            Low & Below {incidents.low}
+      <Grid item xs={12}>
+        <Box sx={{ bgcolor: 'background.default', p: 2, borderRadius: 1 }}>
+          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
+            INCIDENT MANAGEMENT
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+              Critical {incidents.critical}
+            </Box>
+            <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+              High {incidents.high}
+            </Box>
+            <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+              Medium {incidents.medium}
+            </Box>
+            <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+              Low & Below {incidents.low}
+            </Box>
           </Box>
         </Box>
       </Grid>

--- a/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
+++ b/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
@@ -20,16 +20,16 @@ const ResilienceSkimContent = () => {
       <Typography variant="body2" color="text.secondary">
         Incident Management
       </Typography>
-      <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+      <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 0, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
         {incidents.critical}
       </Box>
-      <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+      <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 0, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
         {incidents.high}
       </Box>
-      <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+      <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 0, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
         {incidents.medium}
       </Box>
-      <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 4, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+      <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 1.5, py: 0.5, borderRadius: 0, minWidth: 32, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
         {incidents.low}
       </Box>
     </Box>
@@ -65,16 +65,16 @@ const ResilienceExpandedContent = () => {
           INCIDENT MANAGEMENT
         </Typography>
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+          <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
             Critical {incidents.critical}
           </Box>
-          <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+          <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
             High {incidents.high}
           </Box>
-          <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+          <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
             Medium {incidents.medium}
           </Box>
-          <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 4, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
+          <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
             Low & Below {incidents.low}
           </Box>
         </Box>

--- a/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
+++ b/plugins/helloworld/src/components/ResilienceCard/ResilienceCard.tsx
@@ -36,54 +36,190 @@ const ResilienceSkimContent = () => {
   );
 };
 
-const ResilienceExpandedContent = () => {
-  const { chaosExperiment, incidents } = useResilienceData();
+const ChaosExperimentSection = () => {
+  const { chaosExperiment } = useResilienceData();
   
   return (
-    <Grid container spacing={2}>
-      <Grid item xs={12}>
-        <Box sx={{ bgcolor: 'background.default', p: 2, borderRadius: 1 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-            CHAOS EXPERIMENT
+    <Box sx={{ 
+      bgcolor: 'background.default', 
+      p: 2, 
+      borderRadius: (theme) => theme.shape.borderRadius, 
+      height: '100%', 
+      width: '100%', 
+      display: 'flex', 
+      flexDirection: 'column' 
+    }}>
+      <Typography variant="h6" sx={{ mb: 2, color: 'text.primary', fontWeight: 'bold', fontSize: '1rem' }}>
+        CHAOS EXPERIMENT
+      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        flexDirection: 'column', 
+        gap: 0.5, 
+        flex: 1, 
+        justifyContent: 'center',
+        width: '100%'
+      }}>
+        <Box sx={{ 
+          display: 'grid', 
+          gridTemplateColumns: 'auto auto', 
+          gap: 2, 
+          alignItems: 'center',
+          width: '100%'
+        }}>
+          <Typography variant="body1" sx={{ color: 'text.secondary', textAlign: 'right' }}>
+            Chaos Experiments Compliant:
           </Typography>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
-            <Typography variant="body2">
-              Chaos Experiments Compliant: {chaosExperiment.compliant ? 'Yes' : 'No'}.
-            </Typography>
-            <Typography variant="body2">
-              In Scope: {chaosExperiment.inScope ? 'Yes' : 'No'}
-            </Typography>
-            <Typography variant="body2">
-              Catchup Date: {chaosExperiment.catchupDate}
-            </Typography>
-            <Typography variant="body2">
-              Snapshot Facing Date: {chaosExperiment.snapshotFacingDate || 'NO'}
-            </Typography>
-          </Box>
-        </Box>
-      </Grid>
-      <Grid item xs={12}>
-        <Box sx={{ bgcolor: 'background.default', p: 2, borderRadius: 1 }}>
-          <Typography variant="subtitle2" sx={{ mb: 1, color: 'text.secondary' }}>
-            INCIDENT MANAGEMENT
+          <Typography variant="body1" sx={{ fontWeight: 'bold', textAlign: 'left' }}>
+            {chaosExperiment.compliant ? 'Yes' : 'No'}
           </Typography>
-          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-            <Box sx={{ bgcolor: 'error.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-              Critical {incidents.critical}
-            </Box>
-            <Box sx={{ bgcolor: 'warning.dark', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-              High {incidents.high}
-            </Box>
-            <Box sx={{ bgcolor: 'warning.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-              Medium {incidents.medium}
-            </Box>
-            <Box sx={{ bgcolor: 'info.main', color: 'common.white', px: 2, py: 1, borderRadius: 0, textAlign: 'center', fontSize: '0.875rem', fontWeight: 'bold' }}>
-              Low & Below {incidents.low}
-            </Box>
-          </Box>
+          
+          <Typography variant="body1" sx={{ color: 'text.secondary', textAlign: 'right' }}>
+            In Scope:
+          </Typography>
+          <Typography variant="body1" sx={{ fontWeight: 'bold', textAlign: 'left' }}>
+            {chaosExperiment.inScope ? 'Yes' : 'No'}
+          </Typography>
+          
+          <Typography variant="body1" sx={{ color: 'text.secondary', textAlign: 'right' }}>
+            Catchup Date:
+          </Typography>
+          <Typography variant="body1" sx={{ fontWeight: 'bold', textAlign: 'left' }}>
+            {chaosExperiment.catchupDate}
+          </Typography>
+          
+          <Typography variant="body1" sx={{ color: 'text.secondary', textAlign: 'right' }}>
+            Snapshot Facing Date:
+          </Typography>
+          <Typography variant="body1" sx={{ fontWeight: 'bold', textAlign: 'left' }}>
+            {chaosExperiment.snapshotFacingDate || 'NO'}
+          </Typography>
         </Box>
-      </Grid>
-    </Grid>
+      </Box>
+    </Box>
+  );
+};
+
+const IncidentManagementSection = () => {
+  const { incidents } = useResilienceData();
+  
+  return (
+    <Box sx={{ 
+      bgcolor: 'background.default', 
+      p: 2, 
+      borderRadius: (theme) => theme.shape.borderRadius, 
+      height: '100%', 
+      width: '100%', 
+      display: 'flex', 
+      flexDirection: 'column' 
+    }}>
+      <Typography variant="h6" sx={{ mb: 2, color: 'text.primary', fontWeight: 'bold', fontSize: '1rem' }}>
+        INCIDENT MANAGEMENT
+      </Typography>
+      <Box sx={{ 
+        display: 'flex', 
+        gap: 1, 
+        flexWrap: 'wrap', 
+        width: '100%', 
+        flex: 1, 
+        justifyContent: 'space-between', 
+        alignItems: 'center' 
+      }}>
+        <Box sx={{ 
+          bgcolor: 'error.main', 
+          color: 'common.white', 
+          px: 2, 
+          py: 1.5, 
+          borderRadius: (theme) => theme.shape.borderRadius, 
+          textAlign: 'center', 
+          fontSize: '1rem', 
+          fontWeight: 'bold', 
+          flex: 1, 
+          display: 'flex', 
+          alignItems: 'center', 
+          justifyContent: 'center' 
+        }}>
+          Critical {incidents.critical}
+        </Box>
+        <Box sx={{ 
+          bgcolor: 'warning.dark', 
+          color: 'common.white', 
+          px: 2, 
+          py: 1.5, 
+          borderRadius: (theme) => theme.shape.borderRadius, 
+          textAlign: 'center', 
+          fontSize: '1rem', 
+          fontWeight: 'bold', 
+          flex: 1, 
+          display: 'flex', 
+          alignItems: 'center', 
+          justifyContent: 'center' 
+        }}>
+          High {incidents.high}
+        </Box>
+        <Box sx={{ 
+          bgcolor: 'warning.main', 
+          color: 'common.white', 
+          px: 2, 
+          py: 1.5, 
+          borderRadius: (theme) => theme.shape.borderRadius, 
+          textAlign: 'center', 
+          fontSize: '1rem', 
+          fontWeight: 'bold', 
+          flex: 1, 
+          display: 'flex', 
+          alignItems: 'center', 
+          justifyContent: 'center' 
+        }}>
+          Medium {incidents.medium}
+        </Box>
+        <Box sx={{ 
+          bgcolor: 'info.main', 
+          color: 'common.white', 
+          px: 2, 
+          py: 1.5, 
+          borderRadius: (theme) => theme.shape.borderRadius, 
+          textAlign: 'center', 
+          fontSize: '1rem', 
+          fontWeight: 'bold', 
+          flex: 1, 
+          display: 'flex', 
+          alignItems: 'center', 
+          justifyContent: 'center' 
+        }}>
+          Low & Below {incidents.low}
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const ResilienceExpandedContent = () => {
+  return (
+    <Box sx={{ 
+      display: 'flex', 
+      gap: 2, 
+      width: '100%', 
+      height: '100%',
+      minHeight: 0, // This ensures flex children can shrink/grow properly
+    }}>
+      <Box sx={{ 
+        flex: 1, 
+        minHeight: 0, // Allow flex item to shrink
+        display: 'flex',
+        flexDirection: 'column'
+      }}>
+        <ChaosExperimentSection />
+      </Box>
+      <Box sx={{ 
+        flex: 1, 
+        minHeight: 0, // Allow flex item to shrink
+        display: 'flex',
+        flexDirection: 'column'
+      }}>
+        <IncidentManagementSection />
+      </Box>
+    </Box>
   );
 };
 
@@ -91,22 +227,21 @@ export const ResilienceCard = () => {
   return (
     <CustomInfoCard
       title="Resilience"
-      subheader="Resilience Information"
       dataSources={['Chaos Experiment', 'Incident Management']}
       skimContent={<ResilienceSkimContent />}
       footerButtonsComponent={
         <Box sx={{ display: 'flex', gap: 1 }}>
-          <Button variant="outlined" size="small" onClick={() => console.log('View Details clicked')}>
+          <Button variant="outlined" size="small" onClick={() => { /* TODO: Implement view details */ }}>
             View Details
           </Button>
-          <Button variant="contained" size="small" onClick={() => console.log('Actions clicked')}>
+          <Button variant="contained" size="small" onClick={() => { /* TODO: Implement actions */ }}>
             Actions
           </Button>
         </Box>
       }
       menuActions={[
-        { label: 'Refresh Data', onClick: () => console.log('Refresh') },
-        { label: 'Export', onClick: () => console.log('Export') },
+        { label: 'Refresh Data', onClick: () => { /* TODO: Implement refresh */ } },
+        { label: 'Export', onClick: () => { /* TODO: Implement export */ } },
       ]}
     >
       <ResilienceExpandedContent />

--- a/plugins/helloworld/src/components/ResilienceCard/index.ts
+++ b/plugins/helloworld/src/components/ResilienceCard/index.ts
@@ -1,0 +1,1 @@
+export { ResilienceCard } from './ResilienceCard';

--- a/plugins/helloworld/src/components/ResilienceCard/useResilienceData.ts
+++ b/plugins/helloworld/src/components/ResilienceCard/useResilienceData.ts
@@ -1,0 +1,32 @@
+export interface ResilienceData {
+  chaosExperiment: {
+    compliant: boolean;
+    inScope: boolean;
+    catchupDate: string;
+    snapshotFacingDate: string | null;
+  };
+  incidents: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
+}
+
+export const useResilienceData = (): ResilienceData => {
+  // Static data as per requirements
+  return {
+    chaosExperiment: {
+      compliant: true,
+      inScope: false,
+      catchupDate: 'May 20, 2024',
+      snapshotFacingDate: null,
+    },
+    incidents: {
+      critical: 1,
+      high: 3,
+      medium: 3,
+      low: 10,
+    },
+  };
+};

--- a/plugins/helloworld/src/components/index.ts
+++ b/plugins/helloworld/src/components/index.ts
@@ -7,3 +7,4 @@ Exports all components from the helloworld plugin
 export * from './apiCards';
 export * from './catalogCards';
 export * from './CodeCoverageCard';
+export * from './ResilienceCard';

--- a/plugins/helloworld/src/index.ts
+++ b/plugins/helloworld/src/index.ts
@@ -3,4 +3,5 @@
 export { helloworldPlugin } from './plugin';
 export * from './components/apiCards';
 export * from './components/catalogCards';
-export * from './components/CodeCoverageCard'
+export * from './components/CodeCoverageCard';
+export * from './components/ResilienceCard';


### PR DESCRIPTION
## Summary
- Created ResilienceCard component displaying chaos experiment and incident management information
- Implemented useResilienceData hook that returns static data as per requirements
- Integrated the card into the entity overview page

## Changes
- Added `ResilienceCard` component with MUI 5 components
- Created `useResilienceData` hook returning static resilience data
- Added ResilienceCard to entity page with full-width layout
- Included unit tests for the component

## Test Plan
- [ ] Component renders correctly on entity page
- [ ] Skim content shows compliance status and incident counts
- [ ] Expanded content displays detailed chaos experiment and incident information
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)